### PR TITLE
fix(cors): allow no-Origin requests; ignore Claude worktree state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ env/
 *.swo
 *~
 
+# Claude Code local state (worktrees, per-machine settings)
+.claude/worktrees/
+.claude/settings.local.json
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/backend/server.js
+++ b/backend/server.js
@@ -49,7 +49,9 @@ const allowedOrigins = [
 app.use(
   cors({
     origin(origin, cb) {
-      if (allowedOrigins.includes(origin)) return cb(null, true);
+      // No Origin header = not a browser cross-origin request (direct nav, curl,
+      // health monitors, server-to-server). CORS doesn't apply to these — let them through.
+      if (!origin || allowedOrigins.includes(origin)) return cb(null, true);
       return cb(new Error("CORS policy: origin not allowed"), false);
     },
     credentials: true,


### PR DESCRIPTION
## What
- Fixes a CORS false-positive where any request with **no `Origin` header** (direct browser navigation, curl, uptime/health monitors, server-to-server calls) was rejected and turned into a JSON 500 by the global error handler — even for public routes like `GET /`.
- Adds `.claude/worktrees/` and `.claude/settings.local.json` to `.gitignore` so per-session agent worktrees stop showing up as untracked clutter.

## Why
`Origin` is a browser-enforced header for cross-origin `fetch`/XHR — it's never sent on plain top-level navigation, curl requests, or most server-to-server calls. The previous check (`allowedOrigins.includes(origin)`) treated a missing origin the same as a disallowed one, so hitting the backend URL directly in a browser returned:
```json
{"message":"CORS policy: origin not allowed"}
```
instead of the expected health response. Browser-enforced CORS for real cross-origin requests from disallowed origins is unaffected — only the missing-origin case is now let through.

## Testing
- Verified the CORS check locally: `origin` values in `allowedOrigins` still pass; `undefined` (no header) now passes; any other explicit origin still rejected.
- `git status` confirmed clean after `.gitignore` update — no more `.claude/` clutter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)