### PR TITLE
fix(email): force IPv4 DNS resolution to fix OTP delivery ENETUNREACH on Render

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,13 @@
 // ./server.js
 require("dotenv").config();
+
+// Render's network has no outbound IPv6 route. Since Node 18, DNS resolution
+// order can return the AAAA (IPv6) record first ("Happy Eyeballs"), so any
+// outbound connection to a dual-stack host (e.g. smtp.gmail.com) can pick the
+// unreachable IPv6 address and fail with ENETUNREACH before ever trying IPv4.
+// Force IPv4-first resolution app-wide to avoid this.
+require("dns").setDefaultResultOrder("ipv4first");
+
 const express = require("express");
 const cors = require("cors");
 const path = require("path");

--- a/backend/utils/emailService.js
+++ b/backend/utils/emailService.js
@@ -9,6 +9,7 @@ const transporter = nodemailer.createTransport({
   connectionTimeout: 10000, // 10s — don't hang forever
   greetingTimeout: 10000,
   socketTimeout: 15000,
+  family: 4, // force IPv4 — hosts like Render have no outbound IPv6 route to smtp.gmail.com
 });
 
 const sendOTP = async (email, otp) => {


### PR DESCRIPTION
## What
Every login was failing with `503 Unable to deliver security token` because OTP emails couldn't be sent from Render:
```
Error sending OTP email: Error: connect ENETUNREACH 2607:f8b0:400e:c08::6d:465
code: 'ESOCKET'
```

## Root cause
Render's containers have no outbound IPv6 route. Since Node 18, DNS resolution can return a dual-stack host's AAAA (IPv6) record first ("Happy Eyeballs"), so nodemailer tried connecting to `smtp.gmail.com`'s IPv6 address and died with `ENETUNREACH` — before ever reaching Gmail or checking `SMTP_USER`/`SMTP_PASS` (confirmed those are set correctly on Render).

The 503 fail-closed response itself is correct, intentional behavior from #bd88a60 (stops OTP being bypassable when email fails) — it was just being triggered on every single login because email delivery was unconditionally broken.

## Fix
Two layers:
- `server.js`: `dns.setDefaultResultOrder("ipv4first")` app-wide, so any outbound connection (SMTP or otherwise) prefers IPv4.
- `emailService.js`: `family: 4` pinned directly on the nodemailer transport as defense-in-depth, independent of the global DNS setting.

## Testing
- Syntax-checked both files (`node -c`).
- Root cause matches the exact error/IP/port from the production log; this is the documented fix for this class of Node 18+/Render/container IPv6 issue.
- Recommend verifying on a Render deploy preview / staging before merging to confirm OTP emails actually land, since I can't trigger a live send from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)