### PR TITLE
fix(email): actually force IPv4 for SMTP — family/lookup are both ignored by Nodemailer

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -3,9 +3,14 @@ require("dotenv").config();
 
 // Render's network has no outbound IPv6 route. Since Node 18, DNS resolution
 // order can return the AAAA (IPv6) record first ("Happy Eyeballs"), so any
-// outbound connection to a dual-stack host (e.g. smtp.gmail.com) can pick the
-// unreachable IPv6 address and fail with ENETUNREACH before ever trying IPv4.
-// Force IPv4-first resolution app-wide to avoid this.
+// outbound connection to a dual-stack host can pick the unreachable IPv6
+// address and fail with ENETUNREACH before ever trying IPv4. Force
+// IPv4-first resolution app-wide for anything using Node's built-in resolver
+// (Mongo driver, fetch/undici, etc).
+//
+// NOTE: this does NOT cover Nodemailer — it runs its own DNS resolution via
+// dns.Resolver and ignores this setting. See utils/emailService.js for the
+// SMTP-specific fix.
 require("dns").setDefaultResultOrder("ipv4first");
 
 const express = require("express");

--- a/backend/utils/emailService.js
+++ b/backend/utils/emailService.js
@@ -1,12 +1,26 @@
 const nodemailer = require("nodemailer");
 const dns = require("dns");
 
-// Custom DNS lookup that forces IPv4-only resolution. This is the proper way
-// to ensure Nodemailer never attempts IPv6 connections (which fail with
-// ENETUNREACH on Render). The top-level `family` option is not honored by
-// Nodemailer's SMTP transport, so we must provide a custom lookup function.
-const ipv4OnlyLookup = (hostname, options, callback) => {
-  dns.lookup(hostname, { family: 4 }, callback);
+// Neither the `family` nor `lookup` transport options are read by
+// Nodemailer's own DNS resolution (verified against nodemailer@9's
+// lib/shared/index.js#resolveHostname): it calls dns.resolve4()/resolve6()
+// itself via a `new dns.Resolver()` instance, concatenates the results, and
+// picks the connecting address AT RANDOM from that combined list. On hosts
+// like Render with no outbound IPv6 route, that random pick fails with
+// ENETUNREACH whenever it lands on one of Gmail's AAAA addresses.
+//
+// The only hook that actually reaches nodemailer's resolver is the
+// Resolver prototype itself, so we make resolve6() report no addresses —
+// nodemailer then only ever has IPv4 addresses to pick from. This affects
+// every dns.Resolver instance process-wide, which is fine here since this
+// backend has no legitimate use for outbound IPv6.
+const originalResolve6 = dns.Resolver.prototype.resolve6;
+dns.Resolver.prototype.resolve6 = function ipv4OnlyResolve6(hostname, ...args) {
+  const callback = args[args.length - 1];
+  if (typeof callback === "function") {
+    return process.nextTick(() => callback(null, []));
+  }
+  return originalResolve6.apply(this, [hostname, ...args]);
 };
 
 const transporter = nodemailer.createTransport({
@@ -18,7 +32,6 @@ const transporter = nodemailer.createTransport({
   connectionTimeout: 10000, // 10s — don't hang forever
   greetingTimeout: 10000,
   socketTimeout: 15000,
-  lookup: ipv4OnlyLookup, // force IPv4 — hosts like Render have no outbound IPv6 route to smtp.gmail.com
 });
 
 const sendOTP = async (email, otp) => {


### PR DESCRIPTION
## What
Both prior attempts to force IPv4 for OTP email delivery were no-ops:
- `family: 4` (#114) — not a recognized Nodemailer transport option.
- `lookup: ipv4OnlyLookup` (CodeRabbit's fix in `06ac68b`) — also never read.

Production kept hitting the same `ENETUNREACH` on two different Gmail IPv6 addresses across two separate login attempts, confirming neither fix took effect.

## Root cause (traced against the installed `nodemailer@9.0.3` source)
`lib/shared/index.js#resolveHostname`:
- Nodemailer does its own DNS resolution via a `new dns.Resolver()` instance, calling `resolve4()` **and** `resolve6()` directly — it never reads `options.family` or `options.lookup`.
- It concatenates the IPv4 and IPv6 results, then picks the address to connect to **at random** from the combined list (`formatDNSValue`) — not "IPv4-preferred" despite the ordering in the array.
- By the time it calls `net.connect`/`tls.connect`, it's connecting to a literal resolved IP, not a hostname — so `lookup` (a hostname-resolution hook) is never consulted regardless.

This also explains the pattern we saw: it's a coin flip weighted by however many A/AAAA records Google publishes for `smtp.gmail.com`, and Render has no outbound IPv6 route, so any IPv6 pick dies with `ENETUNREACH`.

Nodemailer's own README acknowledges this class of problem and suggests hardcoding the IP as the only built-in workaround — there's no supported "force IPv4" option in this version.

## Fix
Patch `dns.Resolver.prototype.resolve6` (in `emailService.js`) to report zero addresses. This is the one hook that actually sits in Nodemailer's real resolution path — with no IPv6 addresses to pick from, the random selection can only ever land on IPv4.

Also corrected the `dns.setDefaultResultOrder("ipv4first")` comment in `server.js` (from #114) — that setting doesn't apply to Nodemailer's connection either, since it bypasses Node's default resolver. Left in place since it's still useful for the rest of the app's outbound connections (Mongo, fetch/undici, etc).

## Testing
```
$ node -e "require('./utils/emailService.js'); const dns=require('dns'); const r=new dns.Resolver();
  r.resolve6('smtp.gmail.com', (e,a)=>console.log('resolve6 ->', e, a));
  r.resolve4('smtp.gmail.com', (e,a)=>console.log('resolve4 ->', e, a));"
resolve6 -> null []
resolve4 -> null [ '192.178.211.109' ]
```
Confirms `resolve6` is neutralized while `resolve4` still resolves normally. Recommend verifying with a real login attempt once deployed, since I can't trigger a live send from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)