### PR TITLE
fix(email): replace Gmail SMTP with Resend — Render blocks outbound SMTP

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,3 +12,7 @@ PORT=8000
 
 # CORS Configuration (Frontend URL)
 FRONTEND_URL=https://interview-prep-karo.netlify.app
+
+# Email (OTP delivery via Resend — see ENV_CONFIG.md)
+RESEND_API_KEY=re_your_api_key_here
+EMAIL_FROM=Interview Prep AI <noreply@yourdomain.com>

--- a/backend/ENV_CONFIG.md
+++ b/backend/ENV_CONFIG.md
@@ -22,26 +22,28 @@ RECAPTCHA_SCORE_THRESHOLD=0.5
 
 ---
 
-## Email Configuration (Task 2 - Coming Next)
+## Email Configuration (OTP delivery)
+
+Sent via [Resend](https://resend.com) over HTTPS. Raw Gmail SMTP was dropped —
+Render's network blocks outbound SMTP ports, which made OTP delivery
+unreliable regardless of DNS/IP settings.
 
 ### Required Variables:
 ```env
-# Gmail SMTP Configuration
-EMAIL_SERVICE=gmail
-EMAIL_USER=your-email@gmail.com
-EMAIL_APP_PASSWORD=your_16_char_app_password
+# Resend API key
+RESEND_API_KEY=re_your_api_key_here
 
-# Email Settings
-EMAIL_FROM_NAME=Interview Prep AI
-EMAIL_FROM_ADDRESS=your-email@gmail.com
+# Optional — defaults to Resend's shared onboarding@resend.dev sender if unset.
+# Once you verify a custom domain in the Resend dashboard, set this instead:
+EMAIL_FROM=Interview Prep AI <noreply@yourdomain.com>
 ```
 
-### How to Get Gmail App Password:
-1. Enable 2FA on your Google Account
-2. Visit: https://myaccount.google.com/apppasswords
-3. Select "Mail" and your device
-4. Copy the 16-character password (no spaces)
-5. Add to `.env` as `EMAIL_APP_PASSWORD`
+### How to Get a Resend API Key:
+1. Sign up at https://resend.com
+2. Dashboard → API Keys → Create API Key
+3. Add it to `.env` (and to Render's environment variables) as `RESEND_API_KEY`
+4. (Optional, for production) Dashboard → Domains → verify your own domain,
+   then set `EMAIL_FROM` to an address on that domain
 
 ---
 
@@ -96,12 +98,9 @@ FRONTEND_URL=http://localhost:3000
 RECAPTCHA_SECRET_KEY=your_recaptcha_secret_key_here
 RECAPTCHA_SCORE_THRESHOLD=0.5
 
-# Email Configuration (Gmail SMTP)
-EMAIL_SERVICE=gmail
-EMAIL_USER=your-email@gmail.com
-EMAIL_APP_PASSWORD=your_16_char_app_password
-EMAIL_FROM_NAME=Interview Prep AI
-EMAIL_FROM_ADDRESS=your-email@gmail.com
+# Email Configuration (Resend)
+RESEND_API_KEY=re_your_api_key_here
+EMAIL_FROM=Interview Prep AI <noreply@yourdomain.com>
 
 # OTP Settings
 OTP_EXPIRY_MINUTES=5

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,7 +21,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.17.0",
         "multer": "^2.0.2",
-        "nodemailer": "^9.0.3",
+        "resend": "^6.19.0",
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
@@ -988,6 +988,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -2422,6 +2428,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4187,6 +4199,67 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
+    "node_modules/mongoose/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/mongoose/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/mongoose/node_modules/mongodb": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
@@ -4373,15 +4446,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/nodemailer": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
-      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -4667,6 +4731,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
+      "license": "MIT-0"
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -4846,6 +4916,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.19.0.tgz",
+      "integrity": "sha512-JnEdYnd9WyBDIzunsEZtUF8n3cBKM9SlmySaos/7wwi4sEXKG1Zz4M64VFAyk+278erX01Fq2wHQ3p7OIdPriA==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.5",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -5287,6 +5378,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.17.0",
     "multer": "^2.0.2",
-    "nodemailer": "^9.0.3",
+    "resend": "^6.19.0",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,11 +6,8 @@ require("dotenv").config();
 // outbound connection to a dual-stack host can pick the unreachable IPv6
 // address and fail with ENETUNREACH before ever trying IPv4. Force
 // IPv4-first resolution app-wide for anything using Node's built-in resolver
-// (Mongo driver, fetch/undici, etc).
-//
-// NOTE: this does NOT cover Nodemailer — it runs its own DNS resolution via
-// dns.Resolver and ignores this setting. See utils/emailService.js for the
-// SMTP-specific fix.
+// (Mongo driver, fetch/undici, etc). OTP email delivery no longer goes over
+// raw SMTP (see utils/emailService.js) so it isn't affected either way.
 require("dns").setDefaultResultOrder("ipv4first");
 
 const express = require("express");

--- a/backend/utils/emailService.js
+++ b/backend/utils/emailService.js
@@ -1,63 +1,45 @@
-const nodemailer = require("nodemailer");
-const dns = require("dns");
+const { Resend } = require("resend");
 
-// Neither the `family` nor `lookup` transport options are read by
-// Nodemailer's own DNS resolution (verified against nodemailer@9's
-// lib/shared/index.js#resolveHostname): it calls dns.resolve4()/resolve6()
-// itself via a `new dns.Resolver()` instance, concatenates the results, and
-// picks the connecting address AT RANDOM from that combined list. On hosts
-// like Render with no outbound IPv6 route, that random pick fails with
-// ENETUNREACH whenever it lands on one of Gmail's AAAA addresses.
-//
-// The only hook that actually reaches nodemailer's resolver is the
-// Resolver prototype itself, so we make resolve6() report no addresses —
-// nodemailer then only ever has IPv4 addresses to pick from. This affects
-// every dns.Resolver instance process-wide, which is fine here since this
-// backend has no legitimate use for outbound IPv6.
-const originalResolve6 = dns.Resolver.prototype.resolve6;
-dns.Resolver.prototype.resolve6 = function ipv4OnlyResolve6(hostname, ...args) {
-  const callback = args[args.length - 1];
-  if (typeof callback === "function") {
-    return process.nextTick(() => callback(null, []));
-  }
-  return originalResolve6.apply(this, [hostname, ...args]);
-};
+// Raw SMTP to Gmail was unreliable on Render: connections to smtp.gmail.com
+// either hit ENETUNREACH (no outbound IPv6 route) or, once forced to IPv4,
+// ETIMEDOUT (Render's network blocks outbound SMTP ports outright — a common
+// anti-spam-relay restriction on hosting platforms). Resend delivers over
+// HTTPS (port 443), which sidesteps that whole class of problem.
+const resend = new Resend(process.env.RESEND_API_KEY);
 
-const transporter = nodemailer.createTransport({
-  service: "gmail",
-  auth: {
-    user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASS,
-  },
-  connectionTimeout: 10000, // 10s — don't hang forever
-  greetingTimeout: 10000,
-  socketTimeout: 15000,
-});
+// Resend's shared onboarding@resend.dev sender works without verifying a
+// custom domain — good enough to ship with. Once a domain is verified in the
+// Resend dashboard, set EMAIL_FROM to something like
+// "Interview Prep AI <noreply@yourdomain.com>" for better deliverability/branding.
+const FROM_ADDRESS = process.env.EMAIL_FROM || "Interview Prep AI <onboarding@resend.dev>";
 
 const sendOTP = async (email, otp) => {
-  const mailOptions = {
-    from: `"Interview Prep AI" <${process.env.SMTP_USER}>`,
-    to: email,
-    subject: "Your Login OTP - Interview Prep AI",
-    html: `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #eee; border-radius: 10px;">
-        <h2 style="color: #4F46E5; text-align: center;">Login Verification</h2>
-        <p style="font-size: 16px; color: #374151;">Hello,</p>
-        <p style="font-size: 16px; color: #374151;">You requested to log in to Interview Prep AI. Please use the following One-Time Password (OTP) to complete your login:</p>
-        <div style="background-color: #F3F4F6; padding: 20px; text-align: center; border-radius: 8px; margin: 20px 0;">
-          <h1 style="font-size: 36px; letter-spacing: 8px; color: #1F2937; margin: 0;">${otp}</h1>
-        </div>
-        <p style="font-size: 14px; color: #6B7280;">This OTP is valid for <strong>10 minutes</strong>. Do not share this code with anyone.</p>
-        <p style="font-size: 14px; color: #6B7280;">If you did not request this, please ignore this email.</p>
-        <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;" />
-        <p style="font-size: 14px; color: #9CA3AF; text-align: center;">Interview Prep AI Team</p>
-      </div>
-    `,
-  };
-
   try {
-    const info = await transporter.sendMail(mailOptions);
-    console.log("OTP email sent: %s", info.messageId);
+    const { error } = await resend.emails.send({
+      from: FROM_ADDRESS,
+      to: email,
+      subject: "Your Login OTP - Interview Prep AI",
+      html: `
+        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #eee; border-radius: 10px;">
+          <h2 style="color: #4F46E5; text-align: center;">Login Verification</h2>
+          <p style="font-size: 16px; color: #374151;">Hello,</p>
+          <p style="font-size: 16px; color: #374151;">You requested to log in to Interview Prep AI. Please use the following One-Time Password (OTP) to complete your login:</p>
+          <div style="background-color: #F3F4F6; padding: 20px; text-align: center; border-radius: 8px; margin: 20px 0;">
+            <h1 style="font-size: 36px; letter-spacing: 8px; color: #1F2937; margin: 0;">${otp}</h1>
+          </div>
+          <p style="font-size: 14px; color: #6B7280;">This OTP is valid for <strong>10 minutes</strong>. Do not share this code with anyone.</p>
+          <p style="font-size: 14px; color: #6B7280;">If you did not request this, please ignore this email.</p>
+          <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;" />
+          <p style="font-size: 14px; color: #9CA3AF; text-align: center;">Interview Prep AI Team</p>
+        </div>
+      `,
+    });
+
+    if (error) {
+      console.error("Error sending OTP email:", error);
+      return false;
+    }
+
     return true;
   } catch (error) {
     console.error("Error sending OTP email:", error);


### PR DESCRIPTION
## What
OTP login was still failing after #116 (the IPv6 fix, which is confirmed working — no more `ENETUNREACH`). Production logs show the real, final blocker:

```
Error sending OTP email: Error: Connection timeout
code: 'ETIMEDOUT', command: 'CONN'
```

A 10s hang-then-timeout on the `CONN` phase (vs. an instant rejection) is the signature of a firewall silently dropping the connection, not a routing failure. **Render blocks outbound SMTP ports on this plan** — a common anti-spam-relay restriction on hosting platforms. No amount of DNS/IP-family tuning fixes this from the client side; the port itself is blocked regardless of target IP.

## Fix
Moved OTP delivery to [Resend](https://resend.com) (HTTPS API, port 443 — not blocked by Render). Removed `nodemailer` entirely (only used here) along with the `resolve6` monkeypatch from #116, which no longer has anything to patch.

- `utils/emailService.js` — rewritten around the Resend SDK.
- `package.json` — `-nodemailer`, `+resend`.
- `server.js` — updated comment; `dns.setDefaultResultOrder` no longer needs a Nodemailer caveat since OTP delivery isn't SMTP anymore.
- `ENV_CONFIG.md` / `.env.example` — replaced the Gmail SMTP instructions (which, as a side note, never actually matched the code's real env var names — separate pre-existing doc drift, unrelated to this bug) with `RESEND_API_KEY` / `EMAIL_FROM` setup steps.

## ⚠️ Before merging/deploying
**`RESEND_API_KEY` must be set on Render** or this will fail closed exactly like before (missing key throws in the Resend SDK, caught, `sendOTP` returns `false`, same 503). Sign up at resend.com, grab an API key, add it to Render's environment variables. `EMAIL_FROM` is optional — defaults to Resend's shared `onboarding@resend.dev` sender, which works without verifying a custom domain.

## Testing
- Syntax-checked both changed backend files.
- Loaded the module standalone with a dummy key to confirm it requires cleanly and exports `sendOTP`.
- Can't trigger a real send without a live `RESEND_API_KEY` — please verify with an actual login once the key is set on Render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)