### PR TITLE
fix(email): replace Resend with SendGrid — no domain to verify

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,6 @@ PORT=8000
 # CORS Configuration (Frontend URL)
 FRONTEND_URL=https://interview-prep-karo.netlify.app
 
-# Email (OTP delivery via Resend — see ENV_CONFIG.md)
-RESEND_API_KEY=re_your_api_key_here
-EMAIL_FROM=Interview Prep AI <noreply@yourdomain.com>
+# Email (OTP delivery via SendGrid — see ENV_CONFIG.md)
+SENDGRID_API_KEY=SG.your_api_key_here
+EMAIL_FROM=your-verified-address@example.com

--- a/backend/ENV_CONFIG.md
+++ b/backend/ENV_CONFIG.md
@@ -24,26 +24,33 @@ RECAPTCHA_SCORE_THRESHOLD=0.5
 
 ## Email Configuration (OTP delivery)
 
-Sent via [Resend](https://resend.com) over HTTPS. Raw Gmail SMTP was dropped —
-Render's network blocks outbound SMTP ports, which made OTP delivery
-unreliable regardless of DNS/IP settings.
+Sent via [SendGrid](https://sendgrid.com) over HTTPS. Raw Gmail SMTP was
+dropped — Render's network blocks outbound SMTP ports, which made delivery
+unreliable regardless of DNS/IP settings. Resend was tried next but its
+sandbox mode only allows sending to your own account email unless you verify
+a domain, and this project doesn't own one (it's on a Netlify subdomain).
+SendGrid supports **Single Sender Verification** — verifying ownership of one
+plain email address, no domain required — so that's what's used.
 
 ### Required Variables:
 ```env
-# Resend API key
-RESEND_API_KEY=re_your_api_key_here
+# SendGrid API key
+SENDGRID_API_KEY=SG.your_api_key_here
 
-# Optional — defaults to Resend's shared onboarding@resend.dev sender if unset.
-# Once you verify a custom domain in the Resend dashboard, set this instead:
-EMAIL_FROM=Interview Prep AI <noreply@yourdomain.com>
+# Must exactly match the address verified in SendGrid (see below).
+# SendGrid rejects sends from any address that isn't a verified sender —
+# there's no shared/sandbox fallback, so this is required, not optional.
+EMAIL_FROM=your-verified-address@example.com
 ```
 
-### How to Get a Resend API Key:
-1. Sign up at https://resend.com
-2. Dashboard → API Keys → Create API Key
-3. Add it to `.env` (and to Render's environment variables) as `RESEND_API_KEY`
-4. (Optional, for production) Dashboard → Domains → verify your own domain,
-   then set `EMAIL_FROM` to an address on that domain
+### How to Set Up SendGrid:
+1. Sign up at https://sendgrid.com
+2. Settings → Sender Authentication → **Verify a Single Sender**
+3. Enter any email address you have access to and confirm the link SendGrid
+   sends to that inbox
+4. Settings → API Keys → Create API Key (needs "Mail Send" permission)
+5. Add both to `.env` (and to Render's environment variables):
+   `SENDGRID_API_KEY` and `EMAIL_FROM` (the exact address you verified in step 3)
 
 ---
 
@@ -98,9 +105,9 @@ FRONTEND_URL=http://localhost:3000
 RECAPTCHA_SECRET_KEY=your_recaptcha_secret_key_here
 RECAPTCHA_SCORE_THRESHOLD=0.5
 
-# Email Configuration (Resend)
-RESEND_API_KEY=re_your_api_key_here
-EMAIL_FROM=Interview Prep AI <noreply@yourdomain.com>
+# Email Configuration (SendGrid)
+SENDGRID_API_KEY=SG.your_api_key_here
+EMAIL_FROM=your-verified-address@example.com
 
 # OTP Settings
 OTP_EXPIRY_MINUTES=5

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@google/genai": "^1.12.0",
         "@google/generative-ai": "^0.24.1",
+        "@sendgrid/mail": "^8.1.6",
         "axios": "^1.6.0",
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
@@ -21,7 +22,6 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.17.0",
         "multer": "^2.0.2",
-        "resend": "^6.19.0",
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
@@ -957,6 +957,44 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+      "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+      "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.12",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
@@ -988,12 +1026,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-      "license": "MIT"
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -2020,7 +2052,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2428,12 +2459,6 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4731,12 +4756,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/postal-mime": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
-      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
-      "license": "MIT-0"
-    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -4916,27 +4935,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resend": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.19.0.tgz",
-      "integrity": "sha512-JnEdYnd9WyBDIzunsEZtUF8n3cBKM9SlmySaos/7wwi4sEXKG1Zz4M64VFAyk+278erX01Fq2wHQ3p7OIdPriA==",
-      "license": "MIT",
-      "dependencies": {
-        "postal-mime": "2.7.5",
-        "standardwebhooks": "1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@react-email/render": "*"
-      },
-      "peerDependenciesMeta": {
-        "@react-email/render": {
-          "optional": true
-        }
       }
     },
     "node_modules/resolve": {
@@ -5378,16 +5376,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@google/genai": "^1.12.0",
     "@google/generative-ai": "^0.24.1",
+    "@sendgrid/mail": "^8.1.6",
     "axios": "^1.6.0",
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
@@ -25,7 +26,6 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.17.0",
     "multer": "^2.0.2",
-    "resend": "^6.19.0",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {

--- a/backend/utils/emailService.js
+++ b/backend/utils/emailService.js
@@ -1,48 +1,53 @@
-const { Resend } = require("resend");
+const sgMail = require("@sendgrid/mail");
 
-// Raw SMTP to Gmail was unreliable on Render: connections to smtp.gmail.com
-// either hit ENETUNREACH (no outbound IPv6 route) or, once forced to IPv4,
-// ETIMEDOUT (Render's network blocks outbound SMTP ports outright — a common
-// anti-spam-relay restriction on hosting platforms). Resend delivers over
-// HTTPS (port 443), which sidesteps that whole class of problem.
-const resend = new Resend(process.env.RESEND_API_KEY);
+// Raw SMTP to Gmail was unreliable on Render (ENETUNREACH, then ETIMEDOUT —
+// see git history on this file). Moved to Resend's HTTPS API, which worked,
+// but Resend's unverified-domain sandbox only allows sending to the
+// account's own email address. Domain verification would lift that, but
+// this project doesn't own a domain (it's on a Netlify subdomain), so we're
+// on SendGrid instead: it supports "Single Sender Verification" — verifying
+// ownership of one plain email address (no domain needed) is enough to send
+// to any recipient. Still HTTPS-based (port 443), so the Render SMTP-port
+// block doesn't apply here either.
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 
-// Resend's shared onboarding@resend.dev sender works without verifying a
-// custom domain — good enough to ship with. Once a domain is verified in the
-// Resend dashboard, set EMAIL_FROM to something like
-// "Interview Prep AI <noreply@yourdomain.com>" for better deliverability/branding.
-const FROM_ADDRESS = process.env.EMAIL_FROM || "Interview Prep AI <onboarding@resend.dev>";
+// Must exactly match the address verified in SendGrid under
+// Settings -> Sender Authentication -> Single Sender Verification.
+// SendGrid rejects sends where `from` isn't a verified sender — there's no
+// shared/sandbox fallback address like Resend has, so this is required.
+const FROM_ADDRESS = process.env.EMAIL_FROM;
 
 const sendOTP = async (email, otp) => {
-  try {
-    const { error } = await resend.emails.send({
-      from: FROM_ADDRESS,
-      to: email,
-      subject: "Your Login OTP - Interview Prep AI",
-      html: `
-        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #eee; border-radius: 10px;">
-          <h2 style="color: #4F46E5; text-align: center;">Login Verification</h2>
-          <p style="font-size: 16px; color: #374151;">Hello,</p>
-          <p style="font-size: 16px; color: #374151;">You requested to log in to Interview Prep AI. Please use the following One-Time Password (OTP) to complete your login:</p>
-          <div style="background-color: #F3F4F6; padding: 20px; text-align: center; border-radius: 8px; margin: 20px 0;">
-            <h1 style="font-size: 36px; letter-spacing: 8px; color: #1F2937; margin: 0;">${otp}</h1>
-          </div>
-          <p style="font-size: 14px; color: #6B7280;">This OTP is valid for <strong>10 minutes</strong>. Do not share this code with anyone.</p>
-          <p style="font-size: 14px; color: #6B7280;">If you did not request this, please ignore this email.</p>
-          <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;" />
-          <p style="font-size: 14px; color: #9CA3AF; text-align: center;">Interview Prep AI Team</p>
+  if (!FROM_ADDRESS) {
+    console.error("Error sending OTP email: EMAIL_FROM is not set (must match a SendGrid verified sender)");
+    return false;
+  }
+
+  const message = {
+    to: email,
+    from: { email: FROM_ADDRESS, name: "Interview Prep AI" },
+    subject: "Your Login OTP - Interview Prep AI",
+    html: `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #eee; border-radius: 10px;">
+        <h2 style="color: #4F46E5; text-align: center;">Login Verification</h2>
+        <p style="font-size: 16px; color: #374151;">Hello,</p>
+        <p style="font-size: 16px; color: #374151;">You requested to log in to Interview Prep AI. Please use the following One-Time Password (OTP) to complete your login:</p>
+        <div style="background-color: #F3F4F6; padding: 20px; text-align: center; border-radius: 8px; margin: 20px 0;">
+          <h1 style="font-size: 36px; letter-spacing: 8px; color: #1F2937; margin: 0;">${otp}</h1>
         </div>
-      `,
-    });
+        <p style="font-size: 14px; color: #6B7280;">This OTP is valid for <strong>10 minutes</strong>. Do not share this code with anyone.</p>
+        <p style="font-size: 14px; color: #6B7280;">If you did not request this, please ignore this email.</p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;" />
+        <p style="font-size: 14px; color: #9CA3AF; text-align: center;">Interview Prep AI Team</p>
+      </div>
+    `,
+  };
 
-    if (error) {
-      console.error("Error sending OTP email:", error);
-      return false;
-    }
-
+  try {
+    await sgMail.send(message);
     return true;
   } catch (error) {
-    console.error("Error sending OTP email:", error);
+    console.error("Error sending OTP email:", error?.response?.body || error);
     return false;
   }
 };


### PR DESCRIPTION
## What
Resend is confirmed working (real 403 from their API proves the request round-trips correctly), but it only allows sending to your own account email until a domain is verified:

```
statusCode: 403, name: 'validation_error',
message: 'You can only send testing emails to your own email address... verify a domain at resend.com/domains...'
```

This project doesn't own a domain (frontend is on a Netlify subdomain), so Resend can't be lifted out of sandbox mode as-is.

## Fix
Switched to SendGrid, which supports **Single Sender Verification** — confirming ownership of one plain email address is enough to send to any recipient, no domain required. Still HTTPS (port 443), so none of the earlier Render SMTP-port-blocking issues apply here either.

- `utils/emailService.js` — rewritten around `@sendgrid/mail`. `EMAIL_FROM` is now **required** (SendGrid has no shared/sandbox fallback sender like Resend did) — `sendOTP` fails closed with a clear log message if it's unset, verified locally.
- `package.json` — `-resend`, `+@sendgrid/mail`.
- `ENV_CONFIG.md` / `.env.example` — SendGrid setup steps.

## ⚠️ Before merging/deploying
1. Sign up at sendgrid.com
2. Settings → Sender Authentication → **Verify a Single Sender** — use any email address you can currently access
3. Settings → API Keys → Create API Key ("Mail Send" permission)
4. Set both `SENDGRID_API_KEY` and `EMAIL_FROM` (must exactly match the address verified in step 2) on Render — replacing `RESEND_API_KEY`/old `EMAIL_FROM`

Without these, `sendOTP` fails closed immediately (verified locally) rather than hanging or erroring opaquely — same 503 as before, but for the right reason this time (unconfigured, not broken).

## Testing
- Syntax-checked.
- Loaded standalone with a dummy key — requires cleanly, exports `sendOTP`.
- Verified the fail-closed path: with `SENDGRID_API_KEY` set but no `EMAIL_FROM`, `sendOTP` returns `false` immediately with a clear console error, no live send attempted.
- Can't trigger a real send without a live `SENDGRID_API_KEY` + verified sender — please verify with an actual login once configured on Render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)