### PR TITLE
fix(email): replace Resend with Brevo — SendGrid signup blocked

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,6 @@ PORT=8000
 # CORS Configuration (Frontend URL)
 FRONTEND_URL=https://interview-prep-karo.netlify.app
 
-# Email (OTP delivery via Resend — see ENV_CONFIG.md)
-RESEND_API_KEY=re_your_api_key_here
-EMAIL_FROM=Interview Prep AI <noreply@yourdomain.com>
+# Email (OTP delivery via Brevo — see ENV_CONFIG.md)
+BREVO_API_KEY=your_api_key_here
+EMAIL_FROM=your-verified-address@example.com

--- a/backend/ENV_CONFIG.md
+++ b/backend/ENV_CONFIG.md
@@ -24,26 +24,35 @@ RECAPTCHA_SCORE_THRESHOLD=0.5
 
 ## Email Configuration (OTP delivery)
 
-Sent via [Resend](https://resend.com) over HTTPS. Raw Gmail SMTP was dropped —
-Render's network blocks outbound SMTP ports, which made OTP delivery
-unreliable regardless of DNS/IP settings.
+Sent via [Brevo](https://brevo.com) over HTTPS. Raw Gmail SMTP was dropped —
+Render's network blocks outbound SMTP ports, which made delivery unreliable
+regardless of DNS/IP settings. Resend worked but requires a verified domain
+to send to anyone but the account owner, and this project doesn't own one.
+SendGrid supports domain-free single sender verification, but its
+Twilio-linked signup hit an account-state error before signup could even
+complete. Brevo also supports single sender verification (confirming
+ownership of one plain email address, no domain required) without that
+friction.
 
 ### Required Variables:
 ```env
-# Resend API key
-RESEND_API_KEY=re_your_api_key_here
+# Brevo API key
+BREVO_API_KEY=your_api_key_here
 
-# Optional — defaults to Resend's shared onboarding@resend.dev sender if unset.
-# Once you verify a custom domain in the Resend dashboard, set this instead:
-EMAIL_FROM=Interview Prep AI <noreply@yourdomain.com>
+# Must exactly match the address verified in Brevo (see below).
+# Brevo rejects sends from any address that isn't a verified sender —
+# there's no shared/sandbox fallback, so this is required, not optional.
+EMAIL_FROM=your-verified-address@example.com
 ```
 
-### How to Get a Resend API Key:
-1. Sign up at https://resend.com
-2. Dashboard → API Keys → Create API Key
-3. Add it to `.env` (and to Render's environment variables) as `RESEND_API_KEY`
-4. (Optional, for production) Dashboard → Domains → verify your own domain,
-   then set `EMAIL_FROM` to an address on that domain
+### How to Set Up Brevo:
+1. Sign up at https://brevo.com
+2. Settings → Senders, Domains & Dedicated IPs → **Senders** → Add a Sender
+3. Enter any email address you have access to and confirm the code/link
+   Brevo sends to that inbox
+4. Settings → SMTP & API → API Keys → Generate a new API key
+5. Add both to `.env` (and to Render's environment variables):
+   `BREVO_API_KEY` and `EMAIL_FROM` (the exact address you verified in step 3)
 
 ---
 
@@ -98,9 +107,9 @@ FRONTEND_URL=http://localhost:3000
 RECAPTCHA_SECRET_KEY=your_recaptcha_secret_key_here
 RECAPTCHA_SCORE_THRESHOLD=0.5
 
-# Email Configuration (Resend)
-RESEND_API_KEY=re_your_api_key_here
-EMAIL_FROM=Interview Prep AI <noreply@yourdomain.com>
+# Email Configuration (Brevo)
+BREVO_API_KEY=your_api_key_here
+EMAIL_FROM=your-verified-address@example.com
 
 # OTP Settings
 OTP_EXPIRY_MINUTES=5

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@getbrevo/brevo": "^6.0.3",
         "@google/genai": "^1.12.0",
         "@google/generative-ai": "^0.24.1",
         "axios": "^1.6.0",
@@ -21,7 +22,6 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.17.0",
         "multer": "^2.0.2",
-        "resend": "^6.19.0",
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
@@ -549,6 +549,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@getbrevo/brevo": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@getbrevo/brevo/-/brevo-6.0.3.tgz",
+      "integrity": "sha512-yWBLKoHC8P5HLZ8z6iRuqDYLpCRKPTUETnZOLZzNDWGFYL78y4SHOTxQVrKH5ROX7f4q+SQ19LD3GWtJlIuNXA==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.12.0.tgz",
@@ -988,12 +996,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-      "license": "MIT"
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -2428,12 +2430,6 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4731,12 +4727,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/postal-mime": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
-      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
-      "license": "MIT-0"
-    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -4916,27 +4906,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resend": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.19.0.tgz",
-      "integrity": "sha512-JnEdYnd9WyBDIzunsEZtUF8n3cBKM9SlmySaos/7wwi4sEXKG1Zz4M64VFAyk+278erX01Fq2wHQ3p7OIdPriA==",
-      "license": "MIT",
-      "dependencies": {
-        "postal-mime": "2.7.5",
-        "standardwebhooks": "1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@react-email/render": "*"
-      },
-      "peerDependenciesMeta": {
-        "@react-email/render": {
-          "optional": true
-        }
       }
     },
     "node_modules/resolve": {
@@ -5378,16 +5347,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@getbrevo/brevo": "^6.0.3",
     "@google/genai": "^1.12.0",
     "@google/generative-ai": "^0.24.1",
     "axios": "^1.6.0",
@@ -25,7 +26,6 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.17.0",
     "multer": "^2.0.2",
-    "resend": "^6.19.0",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {

--- a/backend/utils/emailService.js
+++ b/backend/utils/emailService.js
@@ -1,25 +1,33 @@
-const { Resend } = require("resend");
+const { BrevoClient } = require("@getbrevo/brevo");
 
-// Raw SMTP to Gmail was unreliable on Render: connections to smtp.gmail.com
-// either hit ENETUNREACH (no outbound IPv6 route) or, once forced to IPv4,
-// ETIMEDOUT (Render's network blocks outbound SMTP ports outright — a common
-// anti-spam-relay restriction on hosting platforms). Resend delivers over
-// HTTPS (port 443), which sidesteps that whole class of problem.
-const resend = new Resend(process.env.RESEND_API_KEY);
+// Raw SMTP to Gmail was unreliable on Render (ENETUNREACH, then ETIMEDOUT —
+// see git history on this file), so OTP delivery moved to an HTTPS-based
+// transactional email API. Resend worked but its sandbox mode requires a
+// verified domain to send to anyone but the account owner, and this project
+// doesn't own one. SendGrid supports domain-free single sender verification,
+// but its Twilio-linked signup got stuck in an account-state error before
+// signup could even complete. Brevo also supports single sender
+// verification (no domain needed) without that friction.
+const brevo = new BrevoClient({ apiKey: process.env.BREVO_API_KEY });
 
-// Resend's shared onboarding@resend.dev sender works without verifying a
-// custom domain — good enough to ship with. Once a domain is verified in the
-// Resend dashboard, set EMAIL_FROM to something like
-// "Interview Prep AI <noreply@yourdomain.com>" for better deliverability/branding.
-const FROM_ADDRESS = process.env.EMAIL_FROM || "Interview Prep AI <onboarding@resend.dev>";
+// Must match the address verified in Brevo under
+// Settings -> Senders, Domains & Dedicated IPs -> Senders.
+// Brevo rejects sends where `sender` isn't verified — there's no
+// shared/sandbox fallback address, so this is required, not optional.
+const FROM_ADDRESS = process.env.EMAIL_FROM;
 
 const sendOTP = async (email, otp) => {
+  if (!FROM_ADDRESS) {
+    console.error("Error sending OTP email: EMAIL_FROM is not set (must match a Brevo verified sender)");
+    return false;
+  }
+
   try {
-    const { error } = await resend.emails.send({
-      from: FROM_ADDRESS,
-      to: email,
+    await brevo.transactionalEmails.sendTransacEmail({
       subject: "Your Login OTP - Interview Prep AI",
-      html: `
+      sender: { name: "Interview Prep AI", email: FROM_ADDRESS },
+      to: [{ email }],
+      htmlContent: `
         <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #eee; border-radius: 10px;">
           <h2 style="color: #4F46E5; text-align: center;">Login Verification</h2>
           <p style="font-size: 16px; color: #374151;">Hello,</p>
@@ -35,14 +43,9 @@ const sendOTP = async (email, otp) => {
       `,
     });
 
-    if (error) {
-      console.error("Error sending OTP email:", error);
-      return false;
-    }
-
     return true;
   } catch (error) {
-    console.error("Error sending OTP email:", error);
+    console.error("Error sending OTP email:", error?.body || error?.message || error);
     return false;
   }
 };


### PR DESCRIPTION
## What
SendGrid was the intended next step (#120), but its signup flow got stuck in a contradictory account-state error:
- Signup: `[70005] User with the same email address already registered`
- Username recovery for that same email: `No usernames were found associated with this email address`

That's an account-state inconsistency on Twilio/SendGrid's side (they merged identity systems and this is a known class of glitch) — not something fixable from the app or from here. #120 should be closed as abandoned once this merges.

## Fix
Switched to Brevo. Same shape as the SendGrid attempt: HTTPS API (port 443, unaffected by Render's SMTP-port block from earlier in this chain) with **single sender verification** — confirm ownership of one plain email address, no domain required, no Twilio-linked signup friction.

- `utils/emailService.js` — rewritten around `@getbrevo/brevo`'s current `BrevoClient` / `transactionalEmails.sendTransacEmail` API (verified against the installed SDK's own README, not assumed from memory — their API shape changed across major versions). `EMAIL_FROM` is required; `sendOTP` fails closed with a clear log message if it's unset, verified locally.
- `package.json` — `-resend`, `+@getbrevo/brevo`.
- `ENV_CONFIG.md` / `.env.example` — Brevo setup steps.

## ⚠️ Before merging/deploying
1. Sign up at brevo.com
2. Settings → Senders, Domains & Dedicated IPs → **Senders** → Add a Sender — use any email address you can access
3. Settings → SMTP & API → API Keys → generate a key
4. Set `BREVO_API_KEY` and `EMAIL_FROM` (must exactly match the verified sender) on Render, replacing `RESEND_API_KEY`/old `EMAIL_FROM`

## Testing
- Syntax-checked.
- Loaded standalone with a dummy key — requires cleanly, exports `sendOTP`.
- Verified the fail-closed path: `BREVO_API_KEY` set but no `EMAIL_FROM` → `sendOTP` returns `false` immediately with a clear console error, no live send attempted.
- API usage cross-checked against the installed `@getbrevo/brevo` package's own README (`BrevoClient`, `transactionalEmails.sendTransacEmail`, error types) rather than assumed.
- Can't trigger a real send without a live `BREVO_API_KEY` + verified sender — please verify with an actual login once configured on Render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)