### PR TITLE
docs: add LICENSE + CONTRIBUTING.md, fix stale roadmap, add Docker setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to Interview Prep AI
+
+Thanks for considering a contribution! This doc covers how the project is set up and the conventions used here.
+
+## Project Structure
+
+This is a multi-service app:
+
+| Service | Path | Stack |
+|---|---|---|
+| Backend API | `backend/` | Node.js, Express, MongoDB |
+| Frontend | `frontend/interview-perp-ai/` | React, Vite, Tailwind CSS |
+| AI / RAG service | `ai-training/` | Python, FastAPI |
+
+## Getting Set Up
+
+Follow the [Getting Started](README.md#getting-started) section in the README — either the manual per-service setup, or `docker compose up --build` to run everything at once.
+
+Environment variables for the backend are documented in [`backend/ENV_CONFIG.md`](backend/ENV_CONFIG.md); each service also has a `.env.example` you can copy to `.env`.
+
+## Making Changes
+
+1. Fork the repository (or create a branch if you have write access)
+2. Branch off `dev`, not `prod` — `prod` is the deployed default branch, `dev` is where work lands first:
+   ```bash
+   git checkout -b fix/short-description dev
+   ```
+3. Make your change. Keep PRs focused — one fix or feature per PR rather than bundling unrelated changes.
+4. Commit using a [Conventional Commits](https://www.conventionalcommits.org/) prefix (`fix:`, `feat:`, `docs:`, `ci:`, `refactor:`, `chore:`) — this is the convention already used throughout the project's history.
+5. Push and open a PR **against `dev`**.
+
+## Before Opening a PR
+
+- Run the relevant service locally and confirm your change works (`npm run dev` for backend/frontend, or via Docker).
+- If you touched backend routes/controllers, sanity-check the affected endpoints manually — there's no automated test suite yet, so manual verification is the current bar.
+- Keep documentation in sync: if you add or remove an env var, update `backend/ENV_CONFIG.md` and the relevant `.env.example`.
+
+## Reporting Issues
+
+Open a GitHub issue with:
+- What you expected vs. what happened
+- Steps to reproduce
+- Relevant logs/screenshots if it's a runtime error
+
+## Code Style
+
+Match the conventions already in the file you're editing (naming, comment density, error-handling patterns) rather than introducing a new style. There's no enforced linter/formatter config checked into the repo yet, so consistency with surrounding code is the guideline.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shashank Chakraborty
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Interview Prep AI is an intelligent learning platform that transforms how tech p
 * **Build Custom Decks in Seconds:** Create hyper-relevant interview decks for any role, or let the AI build one for you by simply pasting a link to a real job description.
 * **Learn with Spaced Repetition:** A smart SRS algorithm schedules your reviews at the optimal time to ensure knowledge moves into your long-term memory.
 * **Practice Aloud, Get Real Feedback:** Use your voice to practice your answers and receive instant, AI-powered critiques on your content, clarity, and delivery.
+* **Simulate a Real Video Interview:** The AI Interview Coach runs a live video-call simulation with real-time scoring on eye contact, confidence, voice clarity, and more.
+* **Sharpen Your Resume:** Get AI-driven feedback on an existing resume, or build one from scratch with the Smart Resume Builder.
 * **Track Your Growth:** A personalized dashboard visualizes your progress, showing you exactly where you're strong and where you need to focus.
 
 ---
@@ -110,27 +112,44 @@ npm run dev
 npm run dev
 ```
 
+### Alternative: Run Everything with Docker
+
+The repo also ships a `docker-compose.yml` that builds and runs all three services — backend, frontend, and the Python AI/RAG service — together:
+
+```bash
+# Set up env files first (each service needs its own)
+cp backend/.env.example backend/.env          # fill in MONGO_URI, GEMINI_API_KEY, etc.
+cp ai-training/.env.example ai-training/.env   # fill in GEMINI_API_KEY, etc.
+
+# Build and start everything
+docker compose up --build
+```
+
+This starts:
+* **backend** — Express API on [http://localhost:8000](http://localhost:8000)
+* **frontend** — the built React app served via Nginx on [http://localhost:80](http://localhost:80)
+* **ai** — the FastAPI RAG service on [http://localhost:8001](http://localhost:8001)
+
+All three have healthchecks configured, and the frontend waits for the backend to report healthy before starting. Stop everything with `docker compose down`.
+
 ---
 
 ## Roadmap (Future Advancements)
 
-* AI-driven behavioral interview scoring
 * Role-based question banks (SDE, Analyst, Designer)
-* Video interview simulation
-* Resume analysis and feedback
-* Leaderboards and community features
+* Leaderboards
 
 ---
 
 ## Contributing
 
-Contributions are welcome!
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, commit style, and how the project is structured before opening a PR.
 
-1. Fork this repository
-2. Create your feature branch: `git checkout -b feature/amazing-feature`
-3. Commit changes: `git commit -m 'Add amazing feature'`
-4. Push to branch: `git push origin feature/amazing-feature`
-5. Open a Pull Request
+---
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
 
 ---
 


### PR DESCRIPTION
## What
- **README roadmap was stale.** "Future Advancements" listed features that were already built: AI-driven behavioral interview scoring, video interview simulation, and resume analysis all shipped a while ago via the AI Interview Coach and Resume Analyzer/Builder, but never made it into the "What It Does" section. Moved them there and trimmed the roadmap to what's genuinely still not built.
- **No LICENSE.** Added MIT.
- **No CONTRIBUTING.md** (README only had a generic inline 5-step blurb). Added a real one covering the actual service structure, the `dev`-not-`prod` branching convention, and Conventional Commits (already the de facto style in this repo's history).
- **Docker instructions were missing** despite `docker-compose.yml` already existing and running all 3 services. Added a quick-start section with correct ports/env file paths.

## Explicitly left out
- Role-based question banks (SDE/Analyst/Designer) — company-based version existed but was removed from the frontend; not documented as done.
- Recruiter dashboard — backend routes exist (`recruiterRoutes.js`) but no linked frontend page found; not documented as a live feature.

## Testing
Docs-only change — no code touched. Read through the rendered structure for coherence; Docker steps were cross-checked against the actual `docker-compose.yml` (service names, ports, env file paths) and each service's `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)